### PR TITLE
Edit column sizes to fit better by default

### DIFF
--- a/lua/fprofiler/ui/frame.lua
+++ b/lua/fprofiler/ui/frame.lua
@@ -419,7 +419,7 @@ local FRAME = {}
 local frameInstance
 function FRAME:Init()
     self:SetTitle("FProfiler profiling tool")
-    self:SetSize(1920 * 0.9, 1080 * 0.9)
+    self:SetSize(ScrW() * 0.9, ScrH() * 0.9)
     self:Center()
     self:SetVisible(true)
     self:MakePopup()

--- a/lua/fprofiler/ui/frame.lua
+++ b/lua/fprofiler/ui/frame.lua
@@ -245,33 +245,13 @@ local BOTTLENECKTAB = {}
 
 BOTTLENECKTAB.SortByColumn = SortByColumn
 
-function BOTTLENECKTAB:AutoSizeColumns()
-    for i = 1, #self.Columns do
-        local maxWidth = 50
-        local column = self.Columns[i]
-
-        surface.SetFont("DermaDefaultBold")
-        local headerWidth = surface.GetTextSize(column:GetName()) + 50
-        maxWidth = math.max(maxWidth, headerWidth)
-
-        surface.SetFont("DermaDefault")
-        for _, line in pairs(self.Lines) do
-            local text = line:GetColumnText(i)
-            local textWidth = surface.GetTextSize(tostring(text)) + 50
-            maxWidth = math.max(maxWidth, textWidth)
-        end
-
-        column:SetFixedWidth(maxWidth)
-    end
-end
-
 function BOTTLENECKTAB:Init()
     self:SetMultiSelect(false)
-    self:AddColumn("Name")
-    self:AddColumn("Path")
+    self:AddColumn("Name"):SetWidth(200)
+    self:AddColumn("Path"):SetWidth(300)
     self:AddColumn("Lines")
-    self:AddColumn("Amount of times called")
-    self:AddColumn("Total time in ms (inclusive)")
+    self:AddColumn("Amount of times called"):SetWidth(10)
+    self:AddColumn("Total time in ms (inclusive)"):SetWidth(10)
     self:AddColumn("Average time in ms (inclusive)")
 
     FProfiler.UI.onCurrentRealmUpdate("bottlenecks", function(new)
@@ -295,8 +275,6 @@ function BOTTLENECKTAB:Init()
             local line = self:AddLine(table.concat(names, "/"), path, lines, amountCalled, totalTime, avgTime)
             line.data = row
         end
-
-        self:AutoSizeColumns()
     end)
 
     FProfiler.UI.onCurrentRealmUpdate("currentSelected", function(new, old)
@@ -323,30 +301,10 @@ local TOPTENTAB = {}
 
 TOPTENTAB.SortByColumn = SortByColumn
 
-function TOPTENTAB:AutoSizeColumns()
-    for i = 1, #self.Columns do
-        local maxWidth = 50
-        local column = self.Columns[i]
-
-        surface.SetFont("DermaDefaultBold")
-        local headerWidth = surface.GetTextSize(column:GetName()) + 50
-        maxWidth = math.max(maxWidth, headerWidth)
-
-        surface.SetFont("DermaDefault")
-        for _, line in pairs(self.Lines) do
-            local text = line:GetColumnText(i)
-            local textWidth = surface.GetTextSize(tostring(text)) + 50
-            maxWidth = math.max(maxWidth, textWidth)
-        end
-
-        column:SetFixedWidth(maxWidth)
-    end
-end
-
 function TOPTENTAB:Init()
     self:SetMultiSelect(false)
-    self:AddColumn("Name")
-    self:AddColumn("Path")
+    self:AddColumn("Name"):SetWidth(200)
+    self:AddColumn("Path"):SetWidth(300)
     self:AddColumn("Lines")
     self:AddColumn("Runtime in ms")
 
@@ -364,8 +322,6 @@ function TOPTENTAB:Init()
             local line = self:AddLine(name, path, lines, runtime)
             line.data = row
         end
-
-        self:AutoSizeColumns()
     end)
 
     FProfiler.UI.onCurrentRealmUpdate("currentSelected", function(new, old)
@@ -463,7 +419,7 @@ local FRAME = {}
 local frameInstance
 function FRAME:Init()
     self:SetTitle("FProfiler profiling tool")
-    self:SetSize(ScrW() * 0.8, ScrH() * 0.8)
+    self:SetSize(1920 * 0.9, 1080 * 0.9)
     self:Center()
     self:SetVisible(true)
     self:MakePopup()

--- a/lua/fprofiler/ui/frame.lua
+++ b/lua/fprofiler/ui/frame.lua
@@ -245,6 +245,26 @@ local BOTTLENECKTAB = {}
 
 BOTTLENECKTAB.SortByColumn = SortByColumn
 
+function BOTTLENECKTAB:AutoSizeColumns()
+    for i = 1, #self.Columns do
+        local maxWidth = 50
+        local column = self.Columns[i]
+
+        surface.SetFont("DermaDefaultBold")
+        local headerWidth = surface.GetTextSize(column:GetName()) + 50
+        maxWidth = math.max(maxWidth, headerWidth)
+
+        surface.SetFont("DermaDefault")
+        for _, line in pairs(self.Lines) do
+            local text = line:GetColumnText(i)
+            local textWidth = surface.GetTextSize(tostring(text)) + 50
+            maxWidth = math.max(maxWidth, textWidth)
+        end
+
+        column:SetFixedWidth(maxWidth)
+    end
+end
+
 function BOTTLENECKTAB:Init()
     self:SetMultiSelect(false)
     self:AddColumn("Name")
@@ -275,6 +295,8 @@ function BOTTLENECKTAB:Init()
             local line = self:AddLine(table.concat(names, "/"), path, lines, amountCalled, totalTime, avgTime)
             line.data = row
         end
+
+        self:AutoSizeColumns()
     end)
 
     FProfiler.UI.onCurrentRealmUpdate("currentSelected", function(new, old)
@@ -301,6 +323,26 @@ local TOPTENTAB = {}
 
 TOPTENTAB.SortByColumn = SortByColumn
 
+function TOPTENTAB:AutoSizeColumns()
+    for i = 1, #self.Columns do
+        local maxWidth = 50
+        local column = self.Columns[i]
+
+        surface.SetFont("DermaDefaultBold")
+        local headerWidth = surface.GetTextSize(column:GetName()) + 50
+        maxWidth = math.max(maxWidth, headerWidth)
+
+        surface.SetFont("DermaDefault")
+        for _, line in pairs(self.Lines) do
+            local text = line:GetColumnText(i)
+            local textWidth = surface.GetTextSize(tostring(text)) + 50
+            maxWidth = math.max(maxWidth, textWidth)
+        end
+
+        column:SetFixedWidth(maxWidth)
+    end
+end
+
 function TOPTENTAB:Init()
     self:SetMultiSelect(false)
     self:AddColumn("Name")
@@ -322,6 +364,8 @@ function TOPTENTAB:Init()
             local line = self:AddLine(name, path, lines, runtime)
             line.data = row
         end
+
+        self:AutoSizeColumns()
     end)
 
     FProfiler.UI.onCurrentRealmUpdate("currentSelected", function(new, old)


### PR DESCRIPTION
Makes the columns nicer sized so path can always be properly read, before path would be the same width as the lines which caused them to be truncated and unreadable from screenshots
<img width="1415" height="254" alt="image" src="https://github.com/user-attachments/assets/fe5c7a35-d579-4955-b6d6-9db2f70a9e6e" />

At first i wanted to autosize them but turns out you can just do it manually way easier and simpler